### PR TITLE
@marlonbernardes - #17 - Fix flyway and H2 integration

### DIFF
--- a/src/main/java/br/com/registrolivre/Application.java
+++ b/src/main/java/br/com/registrolivre/Application.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
 
-@SpringBootApplication(exclude = FlywayAutoConfiguration.class)
+@SpringBootApplication
 public class Application {
 
     public static void main(String[] args) throws Exception {

--- a/src/main/resources/db/migration/V10__add_issue_to_document.sql
+++ b/src/main/resources/db/migration/V10__add_issue_to_document.sql
@@ -1,4 +1,1 @@
-BEGIN;
-LOCK documents;
 ALTER TABLE documents ADD COLUMN issue_date DATE DEFAULT NULL;
-END;

--- a/src/main/resources/db/migration/V6__replace_trade_name_column_with_bigger_limit.sql
+++ b/src/main/resources/db/migration/V6__replace_trade_name_column_with_bigger_limit.sql
@@ -1,7 +1,4 @@
-BEGIN;
-LOCK companies;
 ALTER TABLE companies ADD COLUMN new_trade_name varchar(150) DEFAULT NULL;
 UPDATE companies SET new_trade_name = trade_name;
 ALTER TABLE companies DROP trade_name;
-ALTER TABLE companies RENAME new_trade_name TO trade_name;
-END;
+ALTER TABLE companies ALTER COLUMN new_trade_name RENAME TO trade_name;

--- a/src/main/resources/db/migration/V7__add_company_name_to_companies_table.sql
+++ b/src/main/resources/db/migration/V7__add_company_name_to_companies_table.sql
@@ -1,4 +1,1 @@
-BEGIN;
-LOCK companies;
 ALTER TABLE companies ADD COLUMN company_name varchar(150) DEFAULT NULL;
-END;

--- a/src/test/java/utils/H2DataSourceConfiguration.java
+++ b/src/test/java/utils/H2DataSourceConfiguration.java
@@ -1,11 +1,12 @@
 package utils;
 
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
-import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
-import javax.sql.DataSource;
-import java.net.URISyntaxException;
+        import org.flywaydb.core.Flyway;
+        import org.springframework.context.annotation.Bean;
+        import org.springframework.context.annotation.Configuration;
+        import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+        import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+        import javax.sql.DataSource;
+        import java.net.URISyntaxException;
 
 @Configuration
 public class H2DataSourceConfiguration {
@@ -13,5 +14,13 @@ public class H2DataSourceConfiguration {
     @Bean
     public DataSource dataSource() throws URISyntaxException {
         return new EmbeddedDatabaseBuilder().setType(EmbeddedDatabaseType.H2).addScript("classpath:db_file.sql").build();
+    }
+
+    @Bean(initMethod = "migrate")
+    public Flyway flyway(DataSource dataSource) throws URISyntaxException {
+        Flyway flyway = new Flyway();
+        flyway.setDataSource(dataSource);
+        flyway.setBaselineOnMigrate(true);
+        return flyway;
     }
 }

--- a/src/test/resources/db_file.sql
+++ b/src/test/resources/db_file.sql
@@ -1,26 +1,11 @@
 CREATE TABLE IF NOT EXISTS companies (
   id   SERIAL PRIMARY KEY,
   cnpj VARCHAR(18) UNIQUE NOT NULL,
-  trade_name VARCHAR(150),
-  company_name VARCHAR(150) DEFAULT NULL,
-  street_name VARCHAR(255) DEFAULT NULL,
-  number VARCHAR(255) DEFAULT NULL,
-  complement VARCHAR(255) DEFAULT NULL,
-  state VARCHAR(255) DEFAULT NULL,
-  city VARCHAR(255) DEFAULT NULL,
-  cep VARCHAR(9) DEFAULT NULL,
-  opening_date DATE DEFAULT NULL
+  trade_name VARCHAR(150)
 );
 
-CREATE TABLE IF NOT EXISTS documents (
-    id   SERIAL PRIMARY KEY,
-    company_id INT NOT NULL REFERENCES companies(id),
-    url VARCHAR(500),
-    issue_date DATE
-);
+INSERT INTO companies VALUES (1, '40.573.872/0001-63', 'Marcenaria Tio Zé');
+INSERT INTO companies VALUES (2, '40.573.872/0001-60', 'Marcenaria Tio João');
 
-INSERT INTO companies VALUES (1, '40.573.872/0001-63', 'Marcenaria Tio Zé', 'Marcenaria LTDA Brasil', null, null, null, null, null, null, null);
-INSERT INTO companies VALUES (2, '40.573.872/0001-60', 'Marcenaria Tio João', 'Marcenaria LTDA Argentina', null, null, null, null, null, null, null);
-
-CREATE SEQUENCE hibernate_sequence INCREMENT 1 START 3;
+CREATE SEQUENCE hibernate_sequence INCREMENT BY 1 START WITH 3;
 


### PR DESCRIPTION
This PR fixes the integration between Flyway and H2. Unfortunately I had to change some migration files, because some statements were not supported by H2 (such as `LOCK <tablename>`). I strongly suggest that you run these migration again on postgresql, just to be sure that everything is working properly.